### PR TITLE
Re-add (redundant) actions table

### DIFF
--- a/ScanCore/ScanCore.sql
+++ b/ScanCore/ScanCore.sql
@@ -1390,3 +1390,12 @@ CREATE TABLE states (
 	FOREIGN KEY(state_host_uuid) REFERENCES hosts(host_uuid)
 );
 ALTER TABLE states OWNER TO #!variable!user!#;
+
+CREATE TABLE history.actions (
+	history_id							bigserial,
+	action_uuid							uuid,
+	action_host_uuid					uuid,						-- UUID of the machine that executed the action
+	action_number						numeric,					-- Number identifying the action that was executed
+	modified_date						timestamp with time zone
+);
+ALTER TABLE history.actions OWNER TO #!variable!user!#;

--- a/ScanCore/ScanCore.sql
+++ b/ScanCore/ScanCore.sql
@@ -1395,7 +1395,10 @@ CREATE TABLE history.actions (
 	history_id							bigserial,
 	action_uuid							uuid,
 	action_host_uuid					uuid,						-- UUID of the machine that executed the action
-	action_number						numeric,					-- Number identifying the action that was executed
+	action_1							numeric,					-- 0 or 1 specifying whether this action was executed
+	action_2							numeric,
+	action_3							numeric,
+	action_4							numeric,
 	modified_date						timestamp with time zone
 );
 ALTER TABLE history.actions OWNER TO #!variable!user!#;

--- a/tools/execute-action
+++ b/tools/execute-action
@@ -9,6 +9,7 @@ no warnings 'recursion';
 $| = 1;
 
 my $THIS_FILE = ($0 =~ /^.*\/(.*)$/)[0];
+my $ACTION_LIST_LENGTH = 4;
 
 my $an = AN::Tools->new({
 	data => {
@@ -63,6 +64,41 @@ print_hash({
 });
 
 my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
+
+# Each element should only contain 0 or 1 representing whether the index+1 action was read.
+my @action_list = ($an->data->{sys}{use_db_fh}->quote(0)) x $ACTION_LIST_LENGTH;
+my $action_list_index = $an->data->{switches}{action} - 1;
+
+$action_list[$action_list_index] = $an->data->{sys}{use_db_fh}->quote(1);
+
+# Prevent unrecognized action numbers (out-of-bounds) by trimming the list.
+@action_list = @action_list[0..($ACTION_LIST_LENGTH - 1)];
+
+my $record_action_query = "
+INSERT INTO
+	history.actions
+(
+	action_uuid,
+	action_host_uuid,
+	".join(",", map { "action_".$_ } 1..$ACTION_LIST_LENGTH ).",
+	modified_date
+) VALUES (
+	".$an->data->{sys}{use_db_fh}->quote($an->Get->uuid()).",
+	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{host_uuid}).",
+	".join(",", @action_list).",
+	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{db_timestamp})."
+);
+";
+
+print_hash({
+	record_action_query	=>	$record_action_query,
+});
+
+$an->DB->do_db_write({
+	query	=>	$record_action_query,
+	source	=>	$THIS_FILE,
+	line	=>	__LINE__
+});
 
 # Only executed when host is a Node.
 #
@@ -150,9 +186,9 @@ if ($an->data->{switches}{action} == 2)
 					else
 					{
 						print_hash({
-							print_hash_message_prefix		=>	"Failed to call:",
-							shell_call	=>	$shell_call,
-							error		=>	$!,
+							print_hash_message_prefix	=>	"Failed to call:",
+							shell_call					=>	$shell_call,
+							error						=>	$!,
 						});
 
 						$an->nice_exit({exit_code => 2});
@@ -166,9 +202,9 @@ if ($an->data->{switches}{action} == 2)
 	else
 	{
 		print_hash({
-			print_hash_message_prefix		=>	"Failed to call:",
-			shell_call	=>	$shell_call,
-			error		=>	$!,
+			print_hash_message_prefix	=>	"Failed to call:",
+			shell_call					=>	$shell_call,
+			error						=>	$!,
 		});
 
 		$an->nice_exit({exit_code => 2});
@@ -206,9 +242,9 @@ elsif ($an->data->{switches}{action} == 3)
 	else
 	{
 		print_hash({
-			print_hash_message_prefix		=>	"Failed to call:",
-			shell_call	=>	$shell_call,
-			error		=>	$!,
+			print_hash_message_prefix	=>	"Failed to call:",
+			shell_call					=>	$shell_call,
+			error						=>	$!,
 		});
 
 		$an->nice_exit({exit_code => 2});
@@ -228,25 +264,3 @@ elsif ($an->data->{switches}{action} == 4)
 		state	=>	$state,
 	});
 }
-
-my record_action_query = "
-INSERT INTO
-	actions
-(
-	action_uuid,
-	action_host_uuid,
-	action_number,
-	modified_date
-) VALUES (
-	".$an->data->{sys}{use_db_fh}->quote($an->Get->uuid()).",
-	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{host_uuid}).",
-	".$an->data->{sys}{use_db_fh}->quote($an->data->{switches}{action}).",
-	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{db_timestamp})."
-);
-";
-
-$an->DB->do_db_write({
-	query	=>	$record_action_query,
-	source	=>	$THIS_FILE,
-	line	=>	__LINE__
-});

--- a/tools/execute-action
+++ b/tools/execute-action
@@ -62,13 +62,13 @@ print_hash({
 	'node-uuid'	=>	$an->data->{switches}{'node-uuid'},
 });
 
+my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
+
 # Only executed when host is a Node.
 #
 # Migrate all servers to this Node.
 if ($an->data->{switches}{action} == 2)
 {
-	my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
-
 	$an->Striker->load_anvil({anvil_uuid => $an->data->{sys}{anvil_uuid}});
 
 	my $node_name = $an->hostname;
@@ -219,8 +219,6 @@ elsif ($an->data->{switches}{action} == 3)
 # Boot the Node specified by the node-uuid flag.
 elsif ($an->data->{switches}{action} == 4)
 {
-	my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
-
 	my $state = $an->ScanCore->target_power({
 		target	=> $an->data->{switches}{'node-uuid'},
 		task	=> "on",
@@ -230,3 +228,25 @@ elsif ($an->data->{switches}{action} == 4)
 		state	=>	$state,
 	});
 }
+
+my record_action_query = "
+INSERT INTO
+	actions
+(
+	action_uuid,
+	action_host_uuid,
+	action_number,
+	modified_date
+) VALUES (
+	".$an->data->{sys}{use_db_fh}->quote($an->Get->uuid()).",
+	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{host_uuid}).",
+	".$an->data->{sys}{use_db_fh}->quote($an->data->{switches}{action}).",
+	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{db_timestamp})."
+);
+";
+
+$an->DB->do_db_write({
+	query	=>	$record_action_query,
+	source	=>	$THIS_FILE,
+	line	=>	__LINE__
+});


### PR DESCRIPTION
This PR brings back the old `decisions` table in the form of a flattened/normalized `actions` table.