### PR TITLE
Revise Actions table to match structure in ScanCore AI

### DIFF
--- a/AN/Tools.pm
+++ b/AN/Tools.pm
@@ -1349,6 +1349,7 @@ sub _set_paths
 	$an->data->{path}{control_libvirtd}                = "/sbin/striker/control_libvirtd";
 	$an->data->{path}{control_shorewall}               = "/sbin/striker/control_shorewall";
 	$an->data->{path}{do_dd}                           = "/sbin/striker/do_dd";
+	$an->data->{path}{'execute-action'}                = "/sbin/striker/execute-action";
 	$an->data->{path}{'striker-configure-vmm'}         = "/sbin/striker/striker-configure-vmm";
 	$an->data->{path}{'striker-delete-anvil'}          = "/sbin/striker/striker-delete-anvil";
 	$an->data->{path}{'striker-merge-dashboards'}      = "/sbin/striker/striker-merge-dashboards";

--- a/ScanCore/ScanCore
+++ b/ScanCore/ScanCore
@@ -2624,7 +2624,7 @@ sub migrate_all_servers_to_here
 {
 	my ($an) = @_;
 	$an->Log->entry({log_level => 2, title_key => "tools_log_0001", title_variables => { function => "migrate_all_servers_to_here" }, message_key => "tools_log_0002", file => $THIS_FILE, line => __LINE__});
-
+	
 	# If the user has disabled auto-migration, exit now.
 	$an->Log->entry({log_level => 2, message_key => "an_variables_0001", message_variables => {
 		name1 => "scancore::disable::preventative_migration", value1 => $an->data->{scancore}{disable}{preventative_migration}, 

--- a/ScanCore/ScanCore
+++ b/ScanCore/ScanCore
@@ -1644,6 +1644,16 @@ ORDER BY
 				$an->Log->entry({log_level => 1, message_key => "scancore_log_0067", message_variables => {
 					node => $host_name, 
 				}, file => $THIS_FILE, line => __LINE__});
+
+				system(
+					$an->data->{path}{'execute-action'},
+					"--action",
+					4,
+					"--node-uuid",
+					$node_uuid,
+					"--record-only",
+				);
+
 				my $state = $an->ScanCore->target_power({
 						target => $node_uuid,
 						task   => "on",
@@ -1668,6 +1678,15 @@ ORDER BY
 		}
 		elsif (($power_is_safe) && ($temperature_is_safe) && ($my_temperature_is_ok))
 		{
+			system(
+				$an->data->{path}{'execute-action'},
+				"--action",
+				4,
+				"--node-uuid",
+				$node_uuid,
+				"--record-only",
+			);
+
 			# Okie!
 			my $state = $an->ScanCore->target_power({
 					target => $node_uuid, 
@@ -2605,7 +2624,7 @@ sub migrate_all_servers_to_here
 {
 	my ($an) = @_;
 	$an->Log->entry({log_level => 2, title_key => "tools_log_0001", title_variables => { function => "migrate_all_servers_to_here" }, message_key => "tools_log_0002", file => $THIS_FILE, line => __LINE__});
-	
+
 	# If the user has disabled auto-migration, exit now.
 	$an->Log->entry({log_level => 2, message_key => "an_variables_0001", message_variables => {
 		name1 => "scancore::disable::preventative_migration", value1 => $an->data->{scancore}{disable}{preventative_migration}, 

--- a/ScanCore/ScanCore.sql
+++ b/ScanCore/ScanCore.sql
@@ -1391,14 +1391,20 @@ CREATE TABLE states (
 );
 ALTER TABLE states OWNER TO #!variable!user!#;
 
+
+-- Table for storing actions dispatched from ScanCore AI.
 CREATE TABLE history.actions (
 	history_id							bigserial,
-	action_uuid							uuid,
-	action_host_uuid					uuid,						-- UUID of the machine that executed the action
-	action_1							numeric,					-- 0 or 1 specifying whether this action was executed
-	action_2							numeric,
-	action_3							numeric,
-	action_4							numeric,
+	uuid								uuid,
+	host_uuid							uuid,						-- UUID of the machine that executed the action
+	node_1_action_1						numeric,					-- 0 or 1 specifying whether this action was executed
+	node_1_action_2						numeric,
+	node_1_action_3						numeric,
+	node_1_action_4						numeric,
+	node_2_action_1						numeric,
+	node_2_action_2						numeric,
+	node_2_action_3						numeric,
+	node_2_action_4						numeric,
 	modified_date						timestamp with time zone
 );
 ALTER TABLE history.actions OWNER TO #!variable!user!#;

--- a/tools/anvil-migrate-server
+++ b/tools/anvil-migrate-server
@@ -127,7 +127,18 @@ sub migrate_server
 	my $pre_migration_arguments  = $an->data->{server_data}{pre_migration_arguments};
 	my $post_migration_script    = $an->data->{server_data}{post_migration_script};
 	my $post_migration_arguments = $an->data->{server_data}{post_migration_arguments};
-	
+
+	system(
+		$an->data->{path}{'execute-action'},
+		"--action",
+		2,
+		"--node-uuid",
+		$an->Get->uuid({
+			get => $migration_target
+		}),
+		"--record-only",
+	);
+
 	# Set the migration type to the default if I didn't read it.
 	if (not $migration_type)
 	{

--- a/tools/anvil-migrate-server
+++ b/tools/anvil-migrate-server
@@ -133,8 +133,8 @@ sub migrate_server
 		"--action",
 		2,
 		"--node-uuid",
-		$an->Get->uuid({
-			get => $migration_target
+		$an->ScanCore->get_node_uuid_from_node_name({
+			node_name => $migration_target
 		}),
 		"--record-only",
 	);

--- a/tools/anvil-safe-stop
+++ b/tools/anvil-safe-stop
@@ -551,7 +551,18 @@ sub shutdown_node
 		name1 => "node",    value1 => $node, 
 		name2 => "migrate", value2 => $migrate,  
 	}, file => $THIS_FILE, line => __LINE__});
-	
+
+	system(
+		$an->data->{path}{'execute-action'},
+		"--action",
+		3,
+		"--node-uuid",
+		$an->ScanCore->get_node_uuid_from_node_name({
+			node_name => $node
+		}),
+		"--record-only",
+	);
+
 	# First, deal with any running servers.
 	my $output  = "";
 	my $proceed = 1;
@@ -732,7 +743,18 @@ sub local_shut_down
 {
 	my ($an) = @_;
 	$an->Log->entry({log_level => 2, title_key => "tools_log_0001", title_variables => { function => "local_shut_down" }, message_key => "tools_log_0002", file => $THIS_FILE, line => __LINE__});
-	
+
+	system(
+		$an->data->{path}{'execute-action'},
+		"--action",
+		3,
+		"--node-uuid",
+		$an->ScanCore->get_node_uuid_from_node_name({
+			node_name => $an->hostname
+		}),
+		"--record-only",
+	);
+
 	# Can we reach the peer?
 	my $peer_access = $an->Check->access({
 		target		=>	$an->data->{sys}{peer_node},

--- a/tools/execute-action
+++ b/tools/execute-action
@@ -11,6 +11,7 @@ $| = 1;
 my $THIS_FILE = ($0 =~ /^.*\/(.*)$/)[0];
 my $N_HOSTS = 2;
 my $N_ACTIONS = 4;
+my $ACTION_ARRAY_LENGTH = $N_HOSTS * $N_ACTIONS;
 
 my $an = AN::Tools->new({
 	data => {
@@ -112,6 +113,13 @@ print_hash({
 });
 
 my @action_array = split(",", $an->data->{switches}{csv});
+
+if (scalar @action_array != $ACTION_ARRAY_LENGTH)
+{
+	print "CSV length does not match the expected length of ".$ACTION_ARRAY_LENGTH."."."\n";
+
+	$an->nice_exit({exit_code => 1});
+}
 
 my $record_action_query = "
 INSERT INTO

--- a/tools/execute-action
+++ b/tools/execute-action
@@ -40,12 +40,7 @@ if (not $an->data->{switches}{node})
 	$an->nice_exit({exit_code => 1});
 }
 
-if (not $an->data->{switches}{csv})
-{
-	print "Missing action CSV."."\n";
-
-	$an->nice_exit({exit_code => 1});
-}
+# ----- Begin function section
 
 sub print_hash
 {
@@ -70,18 +65,17 @@ sub get_node_uuid
 {
 	my $parameter = shift;
 
-	if (not $parameter->{node_number})
+	if (not $parameter->{node})
 	{
 		return;
 	}
 
-	my $get_node_uuid_query = '
+	my $get_node_uuid_query = "
 SELECT nodes.node_uuid
 FROM public.hosts hosts
 INNER JOIN public.nodes nodes
 	ON hosts.host_uuid = nodes.node_host_uuid
-WHERE hosts.host_name LIKE \'an-a%n%'.$parameter->{node_number}.'%\';
-	';
+WHERE hosts.host_name LIKE 'an-a%n%".$parameter->{node}."%';";
 
 	print_hash({
 		get_node_uuid_query	=>	$get_node_uuid_query,
@@ -100,28 +94,68 @@ WHERE hosts.host_name LIKE \'an-a%n%'.$parameter->{node_number}.'%\';
 	return $node_uuid;
 }
 
-my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
-
-my $node_uuid = get_node_uuid({
-	node_number	=>	$an->data->{switches}{node},
-});
-
-print_hash({
-	action		=>	$an->data->{switches}{action},
-	node_uuid	=>	$node_uuid,
-	csv 		=>	$an->data->{switches}{csv},
-});
-
-my @action_array = split(",", $an->data->{switches}{csv});
-
-if (scalar @action_array != $ACTION_ARRAY_LENGTH)
+sub convert_to_action_array
 {
-	print "CSV length does not match the expected length of ".$ACTION_ARRAY_LENGTH."."."\n";
+	my $parameter = shift;
 
-	$an->nice_exit({exit_code => 1});
+	if (not $parameter->{action})
+	{
+		return;
+	}
+
+	if (not $parameter->{node})
+	{
+		return;
+	}
+
+	my @action_array;
+
+	if (($parameter->{action_array})
+		and (scalar @{$parameter->{action_array}} == $ACTION_ARRAY_LENGTH))
+	{
+		@action_array = @{$parameter->{action_array}};
+	}
+	else
+	{
+		@action_array = (0) x $ACTION_ARRAY_LENGTH;
+	}
+
+	my $node_index = $parameter->{node} - 1;
+
+	my $index_to_set = ($node_index * $N_ACTIONS) + $parameter->{action} - 1;
+
+	$action_array[$index_to_set] = 1;
+
+	print_hash({
+		action_array	=>	join(",", @action_array),
+	});
+
+	return @action_array;
 }
 
-my $record_action_query = "
+sub record_action
+{
+	my $parameter = shift;
+
+	if ((not $parameter->{action_array})
+		or (scalar @{$parameter->{action_array}} != $ACTION_ARRAY_LENGTH))
+	{
+		print "CSV length does not match the expected length of ".$ACTION_ARRAY_LENGTH."."."\n";
+
+		return;
+	}
+
+	if (not $parameter->{n_hosts})
+	{
+		return;
+	}
+
+	if (not $parameter->{n_actions})
+	{
+		return;
+	}
+
+	my $record_action_query = "
 INSERT INTO
 	history.actions
 (
@@ -130,29 +164,73 @@ INSERT INTO
 	".join(",",
 		map {
 			my $node_prefix = "node_".$_."_";
-			map { $node_prefix."action_".$_ } 1..$N_ACTIONS
-		} 1..$N_HOSTS
+			map {
+				$node_prefix."action_".$_
+			} 1..$parameter->{n_actions}
+		} 1..$parameter->{n_hosts}
 	).",
 	modified_date
 ) VALUES (
 	".$an->data->{sys}{use_db_fh}->quote($an->Get->uuid()).",
 	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{host_uuid}).",
 	".join(",",
-		map { $an->data->{sys}{use_db_fh}->quote($_) } @action_array
+		map {
+			$an->data->{sys}{use_db_fh}->quote($_)
+		} @{$parameter->{action_array}}
 	).",
 	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{db_timestamp})."
-);
-";
+);";
+
+	print_hash({
+		record_action_query	=>	$record_action_query,
+	});
+
+	$an->DB->do_db_write({
+		query	=>	$record_action_query,
+		source	=>	$THIS_FILE,
+		line	=>	__LINE__
+	});
+}
+
+# ----- End function section
 
 print_hash({
-	record_action_query	=>	$record_action_query,
+	action			=>	$an->data->{switches}{action},
+	node			=>	$an->data->{switches}{node},
+	csv 			=>	$an->data->{switches}{csv},
+	'record-only'	=>	$an->data->{switches}{'record-only'},
 });
 
-$an->DB->do_db_write({
-	query	=>	$record_action_query,
-	source	=>	$THIS_FILE,
-	line	=>	__LINE__
+my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
+
+my $node_uuid = get_node_uuid({
+	node	=>	$an->data->{switches}{node},
 });
+
+my @action_array;
+
+if ($an->data->{switches}{csv})
+{
+	@action_array = split(",", $an->data->{switches}{csv});
+}
+else
+{
+	@action_array = convert_to_action_array({
+		action	=>	$an->data->{switches}{action},
+		node	=>	$an->data->{switches}{node},
+	});
+}
+
+record_action({
+	action_array	=>	[ @action_array ],
+	n_hosts			=>	$N_HOSTS,
+	n_actions		=>	$N_ACTIONS,
+});
+
+if ($an->data->{switches}{'record-only'})
+{
+	$an->nice_exit({exit_code => 0});
+}
 
 # Only executed when host is a Node.
 #

--- a/tools/execute-action
+++ b/tools/execute-action
@@ -33,9 +33,10 @@ if (not $an->data->{switches}{action})
 	$an->nice_exit({exit_code => 1});
 }
 
-if (not $an->data->{switches}{node})
+if ((not $an->data->{switches}{node})
+	and (not $an->data->{switches}{'node-uuid'}))
 {
-	print "Missing node number."."\n";
+	print "Missing node number or UUID."."\n";
 
 	$an->nice_exit({exit_code => 1});
 }
@@ -61,7 +62,7 @@ sub print_hash
 	}
 }
 
-sub get_node_uuid
+sub convert_node_number_to_node_uuid
 {
 	my $parameter = shift;
 
@@ -94,7 +95,52 @@ WHERE hosts.host_name LIKE 'an-a%n%".$parameter->{node}."%';";
 	return $node_uuid;
 }
 
-sub convert_to_action_array
+sub convert_node_uuid_to_node_number
+{
+	my $parameter = shift;
+
+	if (not $parameter->{node_uuid})
+	{
+		return;
+	}
+
+	if (not $parameter->{node_uuid} =~ /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+	{
+		print "Format of the provided Node UUID is invalid."."\n";
+
+		return;
+	}
+
+	my $get_node_number_query = "
+SELECT CAST(
+	SUBSTRING(
+		hosts.host_name,
+		'n([0-9]+)'
+	) AS int
+)
+FROM public.hosts hosts
+INNER JOIN public.nodes nodes
+	ON hosts.host_uuid = nodes.node_host_uuid
+WHERE nodes.node_uuid = '".$parameter->{node_uuid}."';";
+
+	print_hash({
+		get_node_number_query	=>	$get_node_number_query,
+	});
+
+	my $node_number = $an->DB->do_db_query({
+		query	=>	$get_node_number_query,
+		source	=>	$THIS_FILE,
+		line	=>	__LINE__
+	})->[0]->[0];
+
+	print_hash({
+		node_number	=>	$node_number,
+	});
+
+	return $node_number;
+}
+
+sub convert_action_and_node_number_to_action_array
 {
 	my $parameter = shift;
 
@@ -137,11 +183,8 @@ sub record_action
 {
 	my $parameter = shift;
 
-	if ((not $parameter->{action_array})
-		or (scalar @{$parameter->{action_array}} != $ACTION_ARRAY_LENGTH))
+	if (not $parameter->{action_array})
 	{
-		print "CSV length does not match the expected length of ".$ACTION_ARRAY_LENGTH."."."\n";
-
 		return;
 	}
 
@@ -152,6 +195,13 @@ sub record_action
 
 	if (not $parameter->{n_actions})
 	{
+		return;
+	}
+
+	if (scalar @{$parameter->{action_array}} != $ACTION_ARRAY_LENGTH)
+	{
+		print "Action array length does not match the expected length of ".$ACTION_ARRAY_LENGTH."."."\n";
+
 		return;
 	}
 
@@ -203,9 +253,20 @@ print_hash({
 
 my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
 
-my $node_uuid = get_node_uuid({
-	node	=>	$an->data->{switches}{node},
-});
+my $node_uuid;
+
+if ($an->data->{switches}{'node-uuid'})
+{
+	$an->data->{switches}{node} = convert_node_uuid_to_node_number({
+		node_uuid	=>	$an->data->{switches}{'node-uuid'},
+	});
+}
+else
+{
+	$node_uuid = convert_node_number_to_node_uuid({
+		node	=>	$an->data->{switches}{node},
+	});
+}
 
 my @action_array;
 
@@ -215,7 +276,7 @@ if ($an->data->{switches}{csv})
 }
 else
 {
-	@action_array = convert_to_action_array({
+	@action_array = convert_action_and_node_number_to_action_array({
 		action	=>	$an->data->{switches}{action},
 		node	=>	$an->data->{switches}{node},
 	});

--- a/tools/execute-action
+++ b/tools/execute-action
@@ -260,6 +260,8 @@ if ($an->data->{switches}{'node-uuid'})
 	$an->data->{switches}{node} = convert_node_uuid_to_node_number({
 		node_uuid	=>	$an->data->{switches}{'node-uuid'},
 	});
+
+	$node_uuid = $an->data->{switches}{'node-uuid'};
 }
 else
 {
@@ -268,28 +270,28 @@ else
 	});
 }
 
-my @action_array;
-
-if ($an->data->{switches}{csv})
-{
-	@action_array = split(",", $an->data->{switches}{csv});
-}
-else
-{
-	@action_array = convert_action_and_node_number_to_action_array({
-		action	=>	$an->data->{switches}{action},
-		node	=>	$an->data->{switches}{node},
-	});
-}
-
-record_action({
-	action_array	=>	[ @action_array ],
-	n_hosts			=>	$N_HOSTS,
-	n_actions		=>	$N_ACTIONS,
-});
-
 if ($an->data->{switches}{'record-only'})
 {
+	my @action_array;
+
+	if ($an->data->{switches}{csv})
+	{
+		@action_array = split(",", $an->data->{switches}{csv});
+	}
+	else
+	{
+		@action_array = convert_action_and_node_number_to_action_array({
+			action	=>	$an->data->{switches}{action},
+			node	=>	$an->data->{switches}{node},
+		});
+	}
+
+	record_action({
+		action_array	=>	[ @action_array ],
+		n_hosts			=>	$N_HOSTS,
+		n_actions		=>	$N_ACTIONS,
+	});
+
 	$an->nice_exit({exit_code => 0});
 }
 

--- a/tools/execute-action
+++ b/tools/execute-action
@@ -9,7 +9,8 @@ no warnings 'recursion';
 $| = 1;
 
 my $THIS_FILE = ($0 =~ /^.*\/(.*)$/)[0];
-my $ACTION_LIST_LENGTH = 4;
+my $N_HOSTS = 2;
+my $N_ACTIONS = 4;
 
 my $an = AN::Tools->new({
 	data => {
@@ -26,15 +27,21 @@ $an->Get->switches();
 
 if (not $an->data->{switches}{action})
 {
-	print "Missing or invalid action; it must be a positive integer."."\n";
+	print "Missing action number."."\n";
 
 	$an->nice_exit({exit_code => 1});
 }
 
-# Flag node-uuid is not required
-if (($an->data->{switches}{'node-uuid'}) && (not $an->data->{switches}{'node-uuid'} =~ /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/))
+if (not $an->data->{switches}{node})
 {
-	print "Unrecognizable node UUID."."\n";
+	print "Missing node number."."\n";
+
+	$an->nice_exit({exit_code => 1});
+}
+
+if (not $an->data->{switches}{csv})
+{
+	print "Missing action CSV."."\n";
 
 	$an->nice_exit({exit_code => 1});
 }
@@ -58,34 +65,73 @@ sub print_hash
 	}
 }
 
-print_hash({
-	action		=>	$an->data->{switches}{action},
-	'node-uuid'	=>	$an->data->{switches}{'node-uuid'},
-});
+sub get_node_uuid
+{
+	my $parameter = shift;
+
+	if (not $parameter->{node_number})
+	{
+		return;
+	}
+
+	my $get_node_uuid_query = '
+SELECT nodes.node_uuid
+FROM public.hosts hosts
+INNER JOIN public.nodes nodes
+	ON hosts.host_uuid = nodes.node_host_uuid
+WHERE hosts.host_name LIKE \'an-a%n%'.$parameter->{node_number}.'%\';
+	';
+
+	print_hash({
+		get_node_uuid_query	=>	$get_node_uuid_query,
+	});
+
+	my $node_uuid = $an->DB->do_db_query({
+		query	=>	$get_node_uuid_query,
+		source	=>	$THIS_FILE,
+		line	=>	__LINE__
+	})->[0]->[0];
+
+	print_hash({
+		node_uuid	=>	$node_uuid,
+	});
+
+	return $node_uuid;
+}
 
 my $connections = $an->DB->connect_to_databases({file => $THIS_FILE});
 
-# Each element should only contain 0 or 1 representing whether the index+1 action was read.
-my @action_list = ($an->data->{sys}{use_db_fh}->quote(0)) x $ACTION_LIST_LENGTH;
-my $action_list_index = $an->data->{switches}{action} - 1;
+my $node_uuid = get_node_uuid({
+	node_number	=>	$an->data->{switches}{node},
+});
 
-$action_list[$action_list_index] = $an->data->{sys}{use_db_fh}->quote(1);
+print_hash({
+	action		=>	$an->data->{switches}{action},
+	node_uuid	=>	$node_uuid,
+	csv 		=>	$an->data->{switches}{csv},
+});
 
-# Prevent unrecognized action numbers (out-of-bounds) by trimming the list.
-@action_list = @action_list[0..($ACTION_LIST_LENGTH - 1)];
+my @action_array = split(",", $an->data->{switches}{csv});
 
 my $record_action_query = "
 INSERT INTO
 	history.actions
 (
-	action_uuid,
-	action_host_uuid,
-	".join(",", map { "action_".$_ } 1..$ACTION_LIST_LENGTH ).",
+	uuid,
+	host_uuid,
+	".join(",",
+		map {
+			my $node_prefix = "node_".$_."_";
+			map { $node_prefix."action_".$_ } 1..$N_ACTIONS
+		} 1..$N_HOSTS
+	).",
 	modified_date
 ) VALUES (
 	".$an->data->{sys}{use_db_fh}->quote($an->Get->uuid()).",
 	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{host_uuid}).",
-	".join(",", @action_list).",
+	".join(",",
+		map { $an->data->{sys}{use_db_fh}->quote($_) } @action_array
+	).",
 	".$an->data->{sys}{use_db_fh}->quote($an->data->{sys}{db_timestamp})."
 );
 ";
@@ -252,11 +298,11 @@ elsif ($an->data->{switches}{action} == 3)
 }
 # Only executed when host is a Striker.
 #
-# Boot the Node specified by the node-uuid flag.
+# Boot the Node specified by the node flag.
 elsif ($an->data->{switches}{action} == 4)
 {
 	my $state = $an->ScanCore->target_power({
-		target	=> $an->data->{switches}{'node-uuid'},
+		target	=> $node_uuid,
 		task	=> "on",
 	});
 


### PR DESCRIPTION
In the AI, actions are represented by an 8-element array; first 4 0/1 bits represent actions 1 through 4 that affect node 1, similar for the next 4 bits expect for node 2.

The logic to generate the CSV has been moved to the `dispatch-action` script.

Related to https://github.com/Seneca-CDOT/scancore-ai/issues/66.